### PR TITLE
ui: Header Sticky 효과 적용

### DIFF
--- a/fe/src/components/GradientBG.tsx
+++ b/fe/src/components/GradientBG.tsx
@@ -9,7 +9,7 @@ const GradientBackground: React.FC<GradientBackgroundProps> = ({
 }) => {
     return (
         <div className="bg-slate-200">
-            <div className="relative isolate w-dvw min-h-dvh overflow-hidden">
+            <div className="relative isolate w-dvw min-h-dvh">
                 <div
                     aria-hidden="true"
                     className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
@@ -25,7 +25,7 @@ const GradientBackground: React.FC<GradientBackgroundProps> = ({
                 {children}
                 <div
                     aria-hidden="true"
-                    className="absolute inset-x-0 top-[calc(100%-13rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-30rem)]"
+                    className="absolute inset-x-0 top-[calc(100%-13rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-45rem)]"
                 >
                     <div
                         style={{

--- a/fe/src/components/Layouts/Header.tsx
+++ b/fe/src/components/Layouts/Header.tsx
@@ -53,7 +53,7 @@ const Header = () => {
               });
 
     return (
-        <header className="h-21 inset-x-0 top-0 z-50 backdrop-blur-2xl">
+        <header className="h-21 inset-x-0 sticky top-0 z-50 backdrop-blur-2xl">
             <nav
                 aria-label="Global"
                 className="flex items-center justify-between p-6 lg:px-8"

--- a/fe/src/components/MainLayout.tsx
+++ b/fe/src/components/MainLayout.tsx
@@ -10,7 +10,7 @@ interface GradientBackgroundProps {
 const MainLayout: React.FC<GradientBackgroundProps> = ({ children }) => {
     return (
         <>
-            <div className="w-dvw min-h-[calc(100dvh+108px)] flex flex-col justify-start">
+            <div className="w-dvw min-h-[calc(100dvh+108px)] h-100vh flex flex-col justify-start">
                 <Header />
                 <Main>{children}</Main>
                 <Footer />

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -42,7 +42,7 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
-  /* overflow: hidden; */
+  height: 100vh;
 }
 
 #root{


### PR DESCRIPTION
- Header Sticky 효과 적용
    - sticky 적용 안되는 문제 - 이유 - 부모요소 height % or 미적용 - 부모요소 overflow 적용 -> GradientBG 에서 overflow-hidden 이 적용 확인 - 삭제 및 레이아웃 수정