### PR TITLE
ui : 서브 레이아웃 추가 (몰입도 상승) 및 랜딩&상세 페이지 적용

### DIFF
--- a/fe/src/components/Layouts/Main.tsx
+++ b/fe/src/components/Layouts/Main.tsx
@@ -6,7 +6,7 @@ interface GradientBackgroundProps {
 
 const Main: React.FC<GradientBackgroundProps> = ({ children }) => {
     return (
-        <main className="flex-1 flex flex-col items-center justify-center mx-auto max-w-dvw w-dvw">
+        <main className="min-h-[calc(100dvh-96px)] flex-1 flex flex-col items-center justify-center mx-auto max-w-dvw w-dvw">
             {children}
         </main>
     );

--- a/fe/src/components/SubLayout.tsx
+++ b/fe/src/components/SubLayout.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Footer from "./Layouts/Footer";
+import Header from "./Layouts/Header";
+import Main from "./Layouts/Main";
+
+interface GradientBackgroundProps {
+    children: React.ReactNode;
+}
+
+const SubLayout: React.FC<GradientBackgroundProps> = ({ children }) => {
+    return (
+        <>
+            <div className="w-dvw h-100vh flex flex-col justify-start main-bg">
+                <Header />
+                <Main>{children}</Main>
+            </div>
+        </>
+    );
+};
+
+export default SubLayout;

--- a/fe/src/pages/DetailPage.tsx
+++ b/fe/src/pages/DetailPage.tsx
@@ -1,9 +1,9 @@
 import { useLocation, useParams } from "react-router-dom";
-import MainLayout from "../components/MainLayout";
 import useFetchData from "../hooks/useFetchData";
 import { fetchStockDetail } from "../api/api";
 import { formatCurrency } from "../utils/format";
 import { useCallback } from "react";
+import SubLayout from "../components/SubLayout";
 
 const DetailPage = () => {
     const location = useLocation();
@@ -24,7 +24,7 @@ const DetailPage = () => {
 
     if (loadingDetailData || errorDetailData)
         return (
-            <MainLayout>
+            <SubLayout>
                 <div className="w-full min-h-[calc(100dvh-96px)] px-10 py-4 pb-10 grid grid-flow-row grid-rows-[56px_360px_minmax(200px,1fr)] grid-cols-[minmax(280px,1fr)_minmax(280px,1fr)_minmax(280px,1fr)_minmax(280px,1fr)] gap-3 overflow-x-scroll skeleton">
                     <div className="flex flex-row items-center gap-3 col-span-3 skeleton">
                         <div className="w-14 h-14 rounded-xl skeleton-img" />
@@ -83,11 +83,11 @@ const DetailPage = () => {
                         {/* <LivePrice productCode={productCode!} /> */}
                     </div>
                 </div>
-            </MainLayout>
+            </SubLayout>
         );
 
     return (
-        <MainLayout>
+        <SubLayout>
             <div className="w-full min-h-[calc(100dvh-96px)] px-10 py-4 pb-10 grid grid-flow-row grid-rows-[56px_360px_minmax(200px,1fr)] grid-cols-[minmax(280px,1fr)_minmax(280px,1fr)_minmax(280px,1fr)_minmax(280px,1fr)] gap-3 overflow-x-scroll">
                 <div className="flex flex-row items-center gap-3 col-span-3">
                     <img
@@ -158,7 +158,7 @@ const DetailPage = () => {
                     {/* <LivePrice productCode={productCode!} /> */}
                 </div>
             </div>
-        </MainLayout>
+        </SubLayout>
     );
 };
 

--- a/fe/src/pages/LandingPage.tsx
+++ b/fe/src/pages/LandingPage.tsx
@@ -1,9 +1,9 @@
-import MainLayout from "../components/MainLayout";
+import SubLayout from "../components/SubLayout";
 
 const LandingPage = () => {
     return (
-        <MainLayout>
-            <div className="hidden sm:mb-8 sm:flex sm:justify-center flex flex-col gap-1 group">
+        <SubLayout>
+            <div className="sm:mb-8 sm:flex sm:justify-center flex flex-col gap-1 group">
                 <img
                     alt=""
                     src="/AnTrading_Logo_mini_color_neautral.svg"
@@ -41,7 +41,7 @@ const LandingPage = () => {
                     </a>
                 </div>
             </div>
-        </MainLayout>
+        </SubLayout>
     );
 };
 

--- a/fe/src/pages/MainPage.tsx
+++ b/fe/src/pages/MainPage.tsx
@@ -3,6 +3,7 @@ import StockIndex from "../components/Main/StockIndex";
 import MainLayout from "../components/MainLayout";
 import LiveCharts from "../components/Main/LiveCharts";
 import News from "../components/Main/News";
+import Footer from "../components/Layouts/Footer";
 
 const MainPage = () => {
     return (
@@ -17,17 +18,11 @@ const MainPage = () => {
                     <ExchangeRate />
                 </div>
                 {/* 주요 뉴스 */}
-                <div
-                    id="latest-news"
-                    className="block-main col-span-2"
-                >
+                <div id="latest-news" className="block-main col-span-2">
                     <News />
                 </div>
                 {/* 실시간 차트 (급상승, 급하락 종목) 섹션 */}
-                <div
-                    id="live-charts"
-                    className="block-main col-span-2"
-                >
+                <div id="live-charts" className="block-main col-span-2">
                     <LiveCharts />
                 </div>
             </div>


### PR DESCRIPTION
서브 레이아웃 추가 및 랜딩&상세 페이지 적용
- 서브 레이아웃 추가
    1. Footer 컴포넌트 제거 로 인한 화면 몰입도 상승
- 랜딩 페이지 및 상세 페이지 적용
    1. 랜딩 페이지 및 상세 페이지에 적용
    2. 꽉 차는 페이지 구성으로 사용자의 몰입도 상승